### PR TITLE
changed to send results to DM

### DIFF
--- a/plugins/my_mention.py
+++ b/plugins/my_mention.py
@@ -10,7 +10,8 @@ def reply_to_thread(message):
 
 @respond_to('count')
 def count_up_reaction(message):
-    response = subMethod.get_message(message.thread_ts)
+    response = subMethod.get_message(message.body['channel'], 
+                                    message.thread_ts)
     data = response['messages'][0]['reactions']
     sentence = ""
     for datum in data:
@@ -18,4 +19,4 @@ def count_up_reaction(message):
         for user in datum['users']:
             sentence = sentence + "<@" + user + "> "
         sentence = sentence + "\n"
-    message.send(sentence, thread_ts=message.thread_ts)
+    message.direct_reply(sentence)


### PR DESCRIPTION
チャンネル内で集計結果を送ると，投票した人にメンションが行ってしまうようになっていたため，
DMに結果を送ることで，集計結果を聞いた人にだけメンションが行くように修正した．