### PR TITLE
bug fix in check_reactor method

### DIFF
--- a/app/plugins/my_mention.py
+++ b/app/plugins/my_mention.py
@@ -50,14 +50,17 @@ def check_reactor(message):
                                     message.thread_ts)
     target_usergroup = response['messages'][0]['text'].replace('\n', ' ').split()[0].strip('@')
     all_target_audience = subMethod.get_usergroup_member_id(target_usergroup)
-    data = response['messages'][0]['reactions']
-    reacted_users = []
-    reacted_users.extend([user for datum in data for user in datum['users']])
-    target_audience = []
-    target_audience.extend([user for user in all_target_audience if user not in reacted_users])
-    sentence = "*Hasn't yet reacted*\n"
-    for user in target_audience:
-        sentence = sentence + "<@" + user + ">\n"
+    if 'reactions' in response['messages'][0]
+        data = response['messages'][0]['reactions']
+        reacted_users = []
+        reacted_users.extend([user for datum in data for user in datum['users']])
+        target_audience = []
+        target_audience.extend([user for user in all_target_audience if user not in reacted_users])
+        sentence = "*Hasn't yet reacted*\n"
+        for user in target_audience:
+            sentence = sentence + "<@" + user + ">\n"
+    else:
+        sentence = "No one haven't reacted"
     message.direct_reply(sentence)
 
 

--- a/app/plugins/my_mention.py
+++ b/app/plugins/my_mention.py
@@ -48,9 +48,14 @@ def count_up_reaction(message):
 def check_reactor(message):
     response = subMethod.get_message(message.body['channel'],
                                     message.thread_ts)
+    if not response:
+        message.direct_reply("Can't use count method in DM")
+        return
     target_usergroup = response['messages'][0]['text'].replace('\n', ' ').split()[0].strip('@')
     all_target_audience = subMethod.get_usergroup_member_id(target_usergroup)
-    if 'reactions' in response['messages'][0]
+    if len(all_target_audience) == 0:
+        sentence = 'No specified user group'
+    elif 'reactions' in response['messages'][0]:
         data = response['messages'][0]['reactions']
         reacted_users = []
         reacted_users.extend([user for datum in data for user in datum['users']])
@@ -60,7 +65,9 @@ def check_reactor(message):
         for user in target_audience:
             sentence = sentence + "<@" + user + ">\n"
     else:
-        sentence = "No one haven't reacted"
+        sentence = "*Hasn't yet reacted*\n"
+        for user in all_target_audience:
+            sentence = sentence + "<@" + user + ">\n"
     message.direct_reply(sentence)
 
 

--- a/app/plugins/subMethod.py
+++ b/app/plugins/subMethod.py
@@ -45,7 +45,7 @@ def get_usergroup_list():
     try:
         return pickle.load(f)
     except EOFError:
-        return {}
+        return []
 
 def set_usergroup_list(usergroup_list):
     os.chdir('/data')


### PR DESCRIPTION
リアクションのついていないメッセージに対して実行したとき，
ユーザグループの指定のないメッセージに対して実行したとき，
DMで利用されたときに発生した問題にそれぞれ対応した．
また，空ファイルを読んだときに辞書ではなく空配列を突っ込むようにした．